### PR TITLE
refactor(session): 移除session保存时的domain参数

### DIFF
--- a/backend/internal/user/handler/v1/user.go
+++ b/backend/internal/user/handler/v1/user.go
@@ -99,7 +99,7 @@ func (h *UserHandler) Login(c *web.Context, req domain.LoginReq) error {
 	}
 	h.logger.With("header", c.Request().Header).With("host", c.Request().Host).Info("user login", "username", resp.User.Username)
 	if req.Source == consts.LoginSourceBrowser {
-		if _, err := h.session.Save(c, consts.UserSessionName, c.Request().Host, resp.User); err != nil {
+		if _, err := h.session.Save(c, consts.UserSessionName, resp.User); err != nil {
 			return err
 		}
 	}
@@ -199,7 +199,7 @@ func (h *UserHandler) AdminLogin(c *web.Context, req domain.LoginReq) error {
 	}
 
 	h.logger.With("header", c.Request().Header).With("host", c.Request().Host).Info("admin login", "username", resp.Username)
-	if _, err := h.session.Save(c, consts.SessionName, c.Request().Host, resp); err != nil {
+	if _, err := h.session.Save(c, consts.SessionName, resp); err != nil {
 		return err
 	}
 	return c.Success(resp)

--- a/backend/internal/user/usecase/user.go
+++ b/backend/internal/user/usecase/user.go
@@ -485,7 +485,7 @@ func (u *UserUsecase) OAuthCallback(c *web.Context, req *domain.OAuthCallbackReq
 		if session.Source == consts.LoginSourceBrowser {
 			resUser := cvt.From(user, &domain.User{})
 			u.logger.With("user", resUser).With("host", c.Request().Host).DebugContext(ctx, "save user session")
-			if _, err := u.session.Save(c, consts.UserSessionName, c.Request().Host, resUser); err != nil {
+			if _, err := u.session.Save(c, consts.UserSessionName, resUser); err != nil {
 				return nil, err
 			}
 		}

--- a/backend/pkg/session/session.go
+++ b/backend/pkg/session/session.go
@@ -35,7 +35,7 @@ func NewSession(cfg *config.Config) *Session {
 	}
 }
 
-func (s *Session) Save(c echo.Context, name, domain string, data any) (string, error) {
+func (s *Session) Save(c echo.Context, name string, data any) (string, error) {
 	expire := time.Duration(s.cfg.Session.ExpireDay) * 24 * time.Hour
 	id := uuid.New().String()
 	b, err := json.Marshal(data)
@@ -51,7 +51,6 @@ func (s *Session) Save(c echo.Context, name, domain string, data any) (string, e
 		Name:     name,
 		Value:    id,
 		Path:     "/",
-		Domain:   domain,
 		MaxAge:   int(s.cfg.Session.ExpireDay) * 24 * 60 * 60,
 		Secure:   false,
 		HttpOnly: true,


### PR DESCRIPTION
## 📝 变更描述
简化session保存接口，不再需要传递domain参数，统一使用默认配置

## 🔧 修改内容
- 移除`session.Save`方法中的domain参数
- 更新OAuth回调中的session保存调用
- 简化cookie配置，移除显式domain设置

## 🎯 修改原因
- 提升cookie安全性
- 避免跨域安全风险
- 简化session管理逻辑

## 🧪 测试
- [x] 手动测试OAuth登录流程

## 📋 检查清单
- [x] 代码格式化完成
- [x] 静态分析通过
- [x] 遵循项目编码规范
- [x] 更新相关文档（如需要）

## 🔗 相关Issue
无